### PR TITLE
change submit button to say submit

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -58,7 +58,7 @@
                         </div>
                         <div class="Polaris-FormLayout__Item">
                           <div>
-                              <input type="submit" class="Polaris-Button Polaris-Button--primary Polaris-Button"/>
+                              <input type="submit" value="Submit" class="Polaris-Button Polaris-Button--primary Polaris-Button"/>
                           </div>
                         </div>
                       </div>


### PR DESCRIPTION

<img width="99" alt="Screen Shot 2020-03-09 at 4 05 03 PM" src="https://user-images.githubusercontent.com/52986010/76252763-bfd2e880-621f-11ea-978c-34d408119460.png">
It goes from `Submit Query` to `Submit`. I broke this during the lab in a hotfix.