### PR TITLE
Change the class hierarchy to use an abstract Question class

### DIFF
--- a/src/main/java/com/example/survey/SurveyApplication.java
+++ b/src/main/java/com/example/survey/SurveyApplication.java
@@ -22,24 +22,13 @@ public class SurveyApplication {
   @Bean
   public CommandLineRunner demo(SurveyRepo repository) {
     return (args) -> {
-
-      Set<TextQuestion> textQuestions = new HashSet<>();
-      textQuestions.add(new TextQuestion("Text Question 1"));
-      textQuestions.add(new TextQuestion("Text Question 2"));
-
-      Set<OptionQuestion> optionQuestions = new HashSet<>();
-      optionQuestions.add(new OptionQuestion("Option Question 1"));
-      optionQuestions.add(new OptionQuestion("Option Question 2"));
-
-      Set<RangeQuestion> rangeQuestions = new HashSet<>();
-      rangeQuestions.add(new RangeQuestion("Range Question 1", 1, 100));
-      rangeQuestions.add(new RangeQuestion("Range Question 2", 2, 200));
-
       Survey survey = new Survey("Test Survey");
-      survey.setTextQuestions(textQuestions);
-      survey.setOptionQuestions(optionQuestions);
-      survey.setRangeQuestions(rangeQuestions);
-
+      survey.addQuestion(new TextQuestion("Text Question 1"));
+      survey.addQuestion(new TextQuestion("Text Question 2"));
+      survey.addQuestion(new RangeQuestion("Range Question 1", 1, 100));
+      survey.addQuestion(new RangeQuestion("Range Question 2", 2, 200));
+      survey.addQuestion(new OptionQuestion("Option Question 1"));
+      survey.addQuestion(new OptionQuestion("Option Question 2"));
 
       repository.save(survey);
 
@@ -47,21 +36,12 @@ public class SurveyApplication {
       System.out.println("-------------------------------");
       for (Survey s : repository.findAll()) {
         System.out.println("================");
-        System.out.println(s.name);
-        System.out.println("---Text Questions---");
-        for (TextQuestion t : s.getTextQuestions()) {
-          System.out.println(t.toString());
-        }
-        System.out.println("---Option Questions---");
-        for (OptionQuestion o : s.getOptionQuestions()) {
-          System.out.println(o.toString());
-        }
-        System.out.println("---Range Questions---");
-        for (RangeQuestion r : s.getRangeQuestions()) {
-          System.out.println(r.toString());
+        System.out.println(s.getName());
+        System.out.println("---Questions---");
+        for (Question q : s.getQuestions()) {
+          System.out.println(q.toString());
         }
       }
-
     };
   }
 

--- a/src/main/java/com/example/survey/models/OptionQuestion.java
+++ b/src/main/java/com/example/survey/models/OptionQuestion.java
@@ -26,15 +26,6 @@ public class OptionQuestion extends Question {
         this.options = options;
     }
 
-    public String getQuestion() {
-        return question;
-    }
-
-    @Override
-    public void setQuestion(String q) {
-        question = q;
-    }
-
     public Set<String> getOptions() {
         return options;
     }

--- a/src/main/java/com/example/survey/models/OptionQuestion.java
+++ b/src/main/java/com/example/survey/models/OptionQuestion.java
@@ -5,23 +5,20 @@ import java.util.HashSet;
 import java.util.Set;
 
 @Entity
-public class OptionQuestion {
-    @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
-    private long id;
-
-    private String question;
+public class OptionQuestion extends Question {
     private String answer;
     @ElementCollection(
             fetch = FetchType.EAGER
     )
     private Set<String> options;
 
-    public OptionQuestion() {}
+    public OptionQuestion() {
+        options = new HashSet<String>();
+    }
 
     public OptionQuestion(String question) {
         this.question = question;
-        this.options = new HashSet<String>();
+        options = new HashSet<String>();
     }
 
     public OptionQuestion(String question, Set<String> options) {
@@ -31,6 +28,11 @@ public class OptionQuestion {
 
     public String getQuestion() {
         return question;
+    }
+
+    @Override
+    public void setQuestion(String q) {
+        question = q;
     }
 
     public Set<String> getOptions() {
@@ -57,7 +59,7 @@ public class OptionQuestion {
     public String toString() {
         String options = " options (";
         options += String.join(", ", this.options);
-        return question + options +  "): " + answer;
+        return question + options + "): " + answer;
     }
 
 }

--- a/src/main/java/com/example/survey/models/Question.java
+++ b/src/main/java/com/example/survey/models/Question.java
@@ -10,11 +10,15 @@ public abstract class Question {
     protected long id;
     protected String question;
 
-    public abstract String getQuestion();
-
-    public abstract void setQuestion(String q);
-
     public abstract String getAnswer(); // setter handled by subclass
+
+    public void setQuestion(String q) {
+        question = q;
+    }
+
+    public String getQuestion() {
+        return question;
+    }
 
     public void setId(long id) {
         this.id = id;

--- a/src/main/java/com/example/survey/models/Question.java
+++ b/src/main/java/com/example/survey/models/Question.java
@@ -1,19 +1,29 @@
 package com.example.survey.models;
 
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
+import javax.persistence.*;
 
 @Entity
+@Inheritance(strategy = InheritanceType.JOINED)
 public abstract class Question {
     @Id
     @GeneratedValue(strategy = GenerationType.AUTO)
     protected long id;
     protected String question;
+
     public abstract String getQuestion();
+
     public abstract void setQuestion(String q);
+
     public abstract String getAnswer(); // setter handled by subclass
+
+    public void setId(long id) {
+        this.id = id;
+    }
+
+    public long getId() {
+        return id;
+    }
+
     public boolean equals(Object o) {
         if (o instanceof Question) {
             Question q = (Question) o;

--- a/src/main/java/com/example/survey/models/Question.java
+++ b/src/main/java/com/example/survey/models/Question.java
@@ -1,0 +1,24 @@
+package com.example.survey.models;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+
+@Entity
+public abstract class Question {
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    protected long id;
+    protected String question;
+    public abstract String getQuestion();
+    public abstract void setQuestion(String q);
+    public abstract String getAnswer(); // setter handled by subclass
+    public boolean equals(Object o) {
+        if (o instanceof Question) {
+            Question q = (Question) o;
+            return (q.id == id);
+        }
+        return false;
+    }
+}

--- a/src/main/java/com/example/survey/models/RangeQuestion.java
+++ b/src/main/java/com/example/survey/models/RangeQuestion.java
@@ -18,15 +18,6 @@ public class RangeQuestion extends Question {
         this.min = min;
     }
 
-    public String getQuestion() {
-        return question;
-    }
-
-    @Override
-    public void setQuestion(String q) {
-        question = q;
-    }
-
     public void setAnswer(int answer) {
         this.answer = answer;
     }

--- a/src/main/java/com/example/survey/models/RangeQuestion.java
+++ b/src/main/java/com/example/survey/models/RangeQuestion.java
@@ -6,19 +6,13 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 
 @Entity
-public class RangeQuestion {
-    @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
-    private long id;
+public class RangeQuestion extends Question {
+    private int min, max, answer;
 
-    private String question;
-    private Integer min;
-    private Integer max;
-    private Integer answer;
+    public RangeQuestion() {
+    }
 
-    public RangeQuestion() {}
-
-    public RangeQuestion(String question, Integer min, Integer max) {
+    public RangeQuestion(String question, int min, int max) {
         this.question = question;
         this.max = max;
         this.min = min;
@@ -28,12 +22,22 @@ public class RangeQuestion {
         return question;
     }
 
-    public void setAnswer(Integer answer) {
+    @Override
+    public void setQuestion(String q) {
+        question = q;
+    }
+
+    public void setAnswer(int answer) {
         this.answer = answer;
     }
 
     @Override
     public String toString() {
-        return question + " min " + min + " max " + max +": " + answer;
+        return question + " min " + min + " max " + max + ": " + answer;
+    }
+
+    @Override
+    public String getAnswer() {
+        return "" + answer;
     }
 }

--- a/src/main/java/com/example/survey/models/Survey.java
+++ b/src/main/java/com/example/survey/models/Survey.java
@@ -1,7 +1,7 @@
 package com.example.survey.models;
 
 import javax.persistence.*;
-import java.util.List;
+import java.util.HashSet;
 import java.util.Set;
 
 @Entity
@@ -10,76 +10,52 @@ public class Survey {
     @GeneratedValue(strategy = GenerationType.AUTO)
     private long id;
 
-    public String name;
-    public boolean closed;
+    private String name;
+    private boolean closed;
 
     @OneToMany(
             fetch = FetchType.EAGER,
             cascade = CascadeType.ALL,
             orphanRemoval = true
     )
-    public Set<TextQuestion> textQuestions;
-    @OneToMany(
-            fetch = FetchType.EAGER,
-            cascade = CascadeType.ALL,
-            orphanRemoval = true
-    )
-    public Set<OptionQuestion> optionQuestions;
-    @OneToMany(
-            fetch = FetchType.EAGER,
-            cascade = CascadeType.ALL,
-            orphanRemoval = true
-    )
-    public Set<RangeQuestion> rangeQuestions;
+    public Set<Question> questions;
 
-    public Survey() {}
+    public Survey() {
+        questions = new HashSet<>();
+    }
 
     public Survey(String name) {
         this.name = name;
         this.closed = false;
+        questions = new HashSet<>();
     }
 
     public void setClosed(boolean closed) {
         this.closed = closed;
     }
 
+    public boolean isClosed() {
+        return closed;
+    }
+
     public String getName() {
         return name;
     }
 
-    public Set<TextQuestion> getTextQuestions() {
-        return textQuestions;
+    public void setName(String n) {
+        name = n;
     }
 
-    public void setTextQuestions(Set<TextQuestion> textQuestions) {
-        this.textQuestions = textQuestions;
+    public Set<Question> getQuestions() {
+        return questions;
     }
 
-    public void addTextQuestion(TextQuestion question) {
-        this.textQuestions.add(question);
+    public void setQuestions(Set<Question> qs) {
+        questions = qs;
     }
 
-    public Set<OptionQuestion> getOptionQuestions() {
-        return optionQuestions;
+    public void addQuestion(Question q) {
+        questions.add(q);
     }
 
-    public void setOptionQuestions(Set<OptionQuestion> optionQuestions) {
-        this.optionQuestions = optionQuestions;
-    }
-
-    public void addOptionQuestion(OptionQuestion question) {
-        this.optionQuestions.add(question);
-    }
-
-    public Set<RangeQuestion> getRangeQuestions() {
-        return rangeQuestions;
-    }
-
-    public void setRangeQuestions(Set<RangeQuestion> rangeQuestions) {
-        this.rangeQuestions = rangeQuestions;
-    }
-
-    public void addRangeQuestion(RangeQuestion question) {
-        this.rangeQuestions.add(question);
-    }
 }

--- a/src/main/java/com/example/survey/models/TextQuestion.java
+++ b/src/main/java/com/example/survey/models/TextQuestion.java
@@ -13,15 +13,6 @@ public class TextQuestion extends Question {
         this.question = question;
     }
 
-    public String getQuestion() {
-        return question;
-    }
-
-    @Override
-    public void setQuestion(String q) {
-        question = q;
-    }
-
     @Override
     public String getAnswer() {
         return answer;

--- a/src/main/java/com/example/survey/models/TextQuestion.java
+++ b/src/main/java/com/example/survey/models/TextQuestion.java
@@ -3,15 +3,12 @@ package com.example.survey.models;
 import javax.persistence.*;
 
 @Entity
-public class TextQuestion {
-    private String question;
+public class TextQuestion extends Question {
     private String answer;
 
-    @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
-    private long id;
+    public TextQuestion() {
+    }
 
-    public TextQuestion() {}
     public TextQuestion(String question) {
         this.question = question;
     }
@@ -20,6 +17,12 @@ public class TextQuestion {
         return question;
     }
 
+    @Override
+    public void setQuestion(String q) {
+        question = q;
+    }
+
+    @Override
     public String getAnswer() {
         return answer;
     }

--- a/src/test/java/com/example/survey/models/QuestionTest.java
+++ b/src/test/java/com/example/survey/models/QuestionTest.java
@@ -1,0 +1,25 @@
+package com.example.survey.models;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class QuestionTest {
+
+    Question question;
+    @BeforeEach
+    public void BeforeEachTest() {
+         question = new TextQuestion();
+    }
+
+    @Test
+    void testEquals() {
+        question.id = 3;
+        TextQuestion question2 = new TextQuestion();
+        question2.setId(2);
+        assertFalse(question.equals(question2));
+        question2.setId(3);
+        assertTrue(question.equals(question2));
+    }
+}

--- a/src/test/java/com/example/survey/models/SurveyTest.java
+++ b/src/test/java/com/example/survey/models/SurveyTest.java
@@ -14,41 +14,38 @@ public class SurveyTest {
     @BeforeEach
     public void BeforeEachTest() {
         survey = new Survey("Food");
-        survey.setOptionQuestions(new HashSet<OptionQuestion>());
-        survey.setRangeQuestions(new HashSet<RangeQuestion>());
-        survey.setTextQuestions(new HashSet<TextQuestion>());
     }
 
     @Test
     public void addOptionQuestion() {
-        assertEquals(0, survey.getOptionQuestions().size());
+        assertEquals(0, survey.getQuestions().size());
 
         OptionQuestion question = new OptionQuestion("What is your favourite type of pizza?");
-        survey.addOptionQuestion(question);
+        survey.addQuestion(question);
 
-        assertEquals(1, survey.getOptionQuestions().size());
-        assertTrue(survey.getOptionQuestions().contains(question));
+        assertEquals(1, survey.getQuestions().size());
+        assertTrue(survey.getQuestions().contains(question));
     }
 
     @Test
     public void addRangeQuestion() {
-        assertEquals(0, survey.getRangeQuestions().size());
+        assertEquals(0, survey.getQuestions().size());
 
         RangeQuestion question = new RangeQuestion("On a scale of 1 to 10, how much do you like hawaiian pizza?", 1, 10);
-        survey.addRangeQuestion(question);
+        survey.addQuestion(question);
 
-        assertEquals(1, survey.getRangeQuestions().size());
-        assertTrue(survey.getRangeQuestions().contains(question));
+        assertEquals(1, survey.getQuestions().size());
+        assertTrue(survey.getQuestions().contains(question));
     }
 
     @Test
     public void addTextQuestion() {
-        assertEquals(0, survey.getTextQuestions().size());
+        assertEquals(0, survey.getQuestions().size());
 
         TextQuestion question = new TextQuestion("What is your favourite type of pizza?");
-        survey.addTextQuestion(question);
+        survey.addQuestion(question);
 
-        assertEquals(1, survey.getTextQuestions().size());
-        assertTrue(survey.getTextQuestions().contains(question));
+        assertEquals(1, survey.getQuestions().size());
+        assertTrue(survey.getQuestions().contains(question));
     }
 }


### PR DESCRIPTION

Fixes #27 

This makes the UML look like this:

![SimpleSurveyUML](https://user-images.githubusercontent.com/52986010/76263943-a12c1c00-6236-11ea-8fc5-e76cf9f035ae.png)

### Why

A lot of the code for the questions in shared, so I put it in a shared superclass.
The most important decisions I made were:

1. Using an abstract class instead of an interface
2. Specifying the inheritance to be of type `JOINED`
3. Omitting `setAnswer` from the superclass.

---

1. The questions can inherit state. All of them have the fields `String question` and `long id`. Abstract classes allow me to add shared code for these inherited fields. Interfaces don't. The `Question` superclass is marked as an `@Entity` to persist the state.

1. The `JOINED` inheritance type [saves space and provides good support for polymorphism](https://docs.oracle.com/javaee/6/tutorial/doc/bnbqn.html). We don't have any queries that walk the entire hierarchy, so we don't need to worry about slow queries, or polymorphism support in queries. I chose this option to save space in the DB.

1. The RangeQuestion has an answer that is a different type than the other two, so I omitted `setAnswer()` from the Question's abstract method list. If this is an issue in the future we can create an interface just for it. Or we could also store the RangeQuestion's answer as a String.
