### PR TITLE
Multi response questions

### DIFF
--- a/src/main/java/com/example/survey/models/Answer.java
+++ b/src/main/java/com/example/survey/models/Answer.java
@@ -6,7 +6,7 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 
 @Entity
-public class Answer {
+public class Answer implements Comparable {
     @Id
     @GeneratedValue(strategy = GenerationType.AUTO)
     private long id;
@@ -47,5 +47,14 @@ public class Answer {
             return "" + val;
         }
         return response;
+    }
+
+    @Override
+    public int compareTo(Object o) {
+        if (o instanceof Answer) {
+            Answer a = (Answer) o;
+            return val - a.getVal();
+        }
+        return 0;
     }
 }

--- a/src/main/java/com/example/survey/models/Answer.java
+++ b/src/main/java/com/example/survey/models/Answer.java
@@ -1,0 +1,51 @@
+package com.example.survey.models;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+
+@Entity
+public class Answer {
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private long id;
+    int val;
+    String response;
+
+    public Answer() {
+
+    }
+
+    public Answer(int v) {
+        val = v;
+    }
+
+    public Answer(String resp) {
+        response = resp;
+    }
+
+    public void setVal(int v) {
+        val = v;
+        response = "";
+    }
+
+    public int getVal() {
+        return val;
+    }
+
+    public String getResponse() {
+        return response;
+    }
+
+    public void setResponse(String resp) {
+        response = resp;
+    }
+
+    public String toString() {
+        if (response == null) {
+            return "" + val;
+        }
+        return response;
+    }
+}

--- a/src/main/java/com/example/survey/models/OptionQuestion.java
+++ b/src/main/java/com/example/survey/models/OptionQuestion.java
@@ -6,22 +6,19 @@ import java.util.Set;
 
 @Entity
 public class OptionQuestion extends Question {
-    @ElementCollection(targetClass=String.class, fetch = FetchType.EAGER)
-    private Set<Answer> answers;
     @ElementCollection(
             fetch = FetchType.EAGER
     )
     private Set<String> options;
 
     public OptionQuestion() {
+        super();
         options = new HashSet();
-        answers = new HashSet();
     }
 
     public OptionQuestion(String question) {
-        this.question = question;
+        super(question);
         options = new HashSet();
-        answers = new HashSet();
     }
 
     public OptionQuestion(String question, Set<String> options) {
@@ -41,20 +38,10 @@ public class OptionQuestion extends Question {
         this.options.add(option);
     }
 
-
-    public void addAnswer(Answer answer) {
-        answers.add(answer);
-    }
-
     @Override
     public String toString() {
         String options = " options (";
         options += String.join(", ", this.options);
         return question + options + "): " + answers.toString();
-    }
-
-    @Override
-    public Set<Answer> getAnswers() {
-        return answers;
     }
 }

--- a/src/main/java/com/example/survey/models/OptionQuestion.java
+++ b/src/main/java/com/example/survey/models/OptionQuestion.java
@@ -6,6 +6,7 @@ import java.util.Set;
 
 @Entity
 public class OptionQuestion extends Question {
+    @ElementCollection(targetClass=String.class, fetch = FetchType.EAGER)
     private Set<String> answers;
     @ElementCollection(
             fetch = FetchType.EAGER
@@ -49,7 +50,7 @@ public class OptionQuestion extends Question {
     public String toString() {
         String options = " options (";
         options += String.join(", ", this.options);
-        return question + options + "): " + answers;
+        return question + options + "): " + answers.toString();
     }
 
     @Override

--- a/src/main/java/com/example/survey/models/OptionQuestion.java
+++ b/src/main/java/com/example/survey/models/OptionQuestion.java
@@ -7,7 +7,7 @@ import java.util.Set;
 @Entity
 public class OptionQuestion extends Question {
     @ElementCollection(targetClass=String.class, fetch = FetchType.EAGER)
-    private Set<String> answers;
+    private Set<Answer> answers;
     @ElementCollection(
             fetch = FetchType.EAGER
     )
@@ -42,7 +42,7 @@ public class OptionQuestion extends Question {
     }
 
 
-    public void addAnswer(String answer) {
+    public void addAnswer(Answer answer) {
         answers.add(answer);
     }
 
@@ -54,7 +54,7 @@ public class OptionQuestion extends Question {
     }
 
     @Override
-    public Set<String> getAnswers() {
+    public Set<Answer> getAnswers() {
         return answers;
     }
 }

--- a/src/main/java/com/example/survey/models/OptionQuestion.java
+++ b/src/main/java/com/example/survey/models/OptionQuestion.java
@@ -6,19 +6,21 @@ import java.util.Set;
 
 @Entity
 public class OptionQuestion extends Question {
-    private String answer;
+    private Set<String> answers;
     @ElementCollection(
             fetch = FetchType.EAGER
     )
     private Set<String> options;
 
     public OptionQuestion() {
-        options = new HashSet<String>();
+        options = new HashSet();
+        answers = new HashSet();
     }
 
     public OptionQuestion(String question) {
         this.question = question;
-        options = new HashSet<String>();
+        options = new HashSet();
+        answers = new HashSet();
     }
 
     public OptionQuestion(String question, Set<String> options) {
@@ -38,19 +40,20 @@ public class OptionQuestion extends Question {
         this.options.add(option);
     }
 
-    public String getAnswer() {
-        return answer;
-    }
 
-    public void setAnswer(String answer) {
-        this.answer = answer;
+    public void addAnswer(String answer) {
+        answers.add(answer);
     }
 
     @Override
     public String toString() {
         String options = " options (";
         options += String.join(", ", this.options);
-        return question + options + "): " + answer;
+        return question + options + "): " + answers;
     }
 
+    @Override
+    public Set<String> getAnswers() {
+        return answers;
+    }
 }

--- a/src/main/java/com/example/survey/models/OptionQuestion.java
+++ b/src/main/java/com/example/survey/models/OptionQuestion.java
@@ -22,7 +22,7 @@ public class OptionQuestion extends Question {
     }
 
     public OptionQuestion(String question, Set<String> options) {
-        this.question = question;
+        super(question);
         this.options = options;
     }
 

--- a/src/main/java/com/example/survey/models/Question.java
+++ b/src/main/java/com/example/survey/models/Question.java
@@ -1,6 +1,7 @@
 package com.example.survey.models;
 
 import javax.persistence.*;
+import java.util.HashSet;
 import java.util.Set;
 
 @Entity
@@ -10,10 +11,25 @@ public abstract class Question {
     @GeneratedValue(strategy = GenerationType.AUTO)
     protected long id;
     protected String question;
+    @ElementCollection(targetClass = String.class, fetch = FetchType.EAGER)
+    protected Set<Answer> answers;
 
-    public abstract Set<Answer> getAnswers();
+    public Question() {
+        answers = new HashSet();
+    }
 
-    public abstract void addAnswer(Answer ans);
+    public Question(String ques) {
+        question = ques;
+        answers = new HashSet();
+    }
+
+    public Set<Answer> getAnswers() {
+        return answers;
+    }
+
+    public void addAnswer(Answer ans) {
+        answers.add(ans);
+    }
 
     public void setQuestion(String q) {
         question = q;

--- a/src/main/java/com/example/survey/models/Question.java
+++ b/src/main/java/com/example/survey/models/Question.java
@@ -11,9 +11,9 @@ public abstract class Question {
     protected long id;
     protected String question;
 
-    public abstract Set<String> getAnswers();
+    public abstract Set<Answer> getAnswers();
 
-    public abstract void addAnswer(String ans);
+    public abstract void addAnswer(Answer ans);
 
     public void setQuestion(String q) {
         question = q;

--- a/src/main/java/com/example/survey/models/Question.java
+++ b/src/main/java/com/example/survey/models/Question.java
@@ -1,6 +1,7 @@
 package com.example.survey.models;
 
 import javax.persistence.*;
+import java.util.Set;
 
 @Entity
 @Inheritance(strategy = InheritanceType.JOINED)
@@ -10,7 +11,9 @@ public abstract class Question {
     protected long id;
     protected String question;
 
-    public abstract String getAnswer(); // setter handled by subclass
+    public abstract Set<String> getAnswers();
+
+    public abstract void addAnswer(String ans);
 
     public void setQuestion(String q) {
         question = q;

--- a/src/main/java/com/example/survey/models/RangeQuestion.java
+++ b/src/main/java/com/example/survey/models/RangeQuestion.java
@@ -10,7 +10,7 @@ import java.util.Set;
 public class RangeQuestion extends Question {
     private int min, max;
     @ElementCollection(targetClass=Integer.class, fetch = FetchType.EAGER)
-    private Set<Integer> answers;
+    private Set<Answer> answers;
 
     public RangeQuestion() {
         answers = new HashSet();
@@ -23,33 +23,18 @@ public class RangeQuestion extends Question {
         answers = new HashSet();
     }
 
-    public void addAnswer(int answer) {
-        answers.add(answer);
-    }
-
     @Override
     public String toString() {
         return question + " min " + min + " max " + max + ": " + answers.toString();
     }
 
     @Override
-    public Set<String> getAnswers() {
-        HashSet<String> toret = new HashSet();
-        for (int ans : answers) {
-            toret.add("" + ans);
-        }
-        return toret;
+    public Set<Answer> getAnswers() {
+        return answers;
     }
 
     @Override
-    public void addAnswer(String ans) {
-        int response;
-        try {
-            response = Integer.parseInt(ans);
-        } catch (NumberFormatException e) {
-            response = 0;
-        }
-        addAnswer(response);
+    public void addAnswer(Answer ans) {
+        answers.add(ans);
     }
-
 }

--- a/src/main/java/com/example/survey/models/RangeQuestion.java
+++ b/src/main/java/com/example/survey/models/RangeQuestion.java
@@ -1,15 +1,15 @@
 package com.example.survey.models;
 
+import javax.persistence.ElementCollection;
 import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
+import javax.persistence.FetchType;
 import java.util.HashSet;
 import java.util.Set;
 
 @Entity
 public class RangeQuestion extends Question {
     private int min, max;
+    @ElementCollection(targetClass=Integer.class, fetch = FetchType.EAGER)
     private Set<Integer> answers;
 
     public RangeQuestion() {
@@ -29,7 +29,7 @@ public class RangeQuestion extends Question {
 
     @Override
     public String toString() {
-        return question + " min " + min + " max " + max + ": " + answers;
+        return question + " min " + min + " max " + max + ": " + answers.toString();
     }
 
     @Override
@@ -51,4 +51,5 @@ public class RangeQuestion extends Question {
         }
         addAnswer(response);
     }
+
 }

--- a/src/main/java/com/example/survey/models/RangeQuestion.java
+++ b/src/main/java/com/example/survey/models/RangeQuestion.java
@@ -1,6 +1,10 @@
 package com.example.survey.models;
 
+import com.sun.tools.javac.util.List;
+
 import javax.persistence.Entity;
+import java.util.ArrayList;
+import java.util.Collections;
 
 @Entity
 public class RangeQuestion extends Question {
@@ -16,8 +20,23 @@ public class RangeQuestion extends Question {
         this.min = min;
     }
 
+    public int getMin() { return min; }
+    public int getMax() { return max; }
+    public void setMin(int m) { min = m; }
+    public void setMax(int m) { max = m; }
+
+    @Override
+    public void addAnswer(Answer ans) {
+        if (ans.getVal() <= max && ans.getVal() >= min) {
+            super.addAnswer(ans);
+            return;
+        }
+    }
+
     @Override
     public String toString() {
-        return question + " min " + min + " max " + max + ": " + answers.toString();
+        ArrayList<Answer> sorted = new ArrayList<Answer>(answers);
+        Collections.sort(sorted);
+        return question + " min " + min + " max " + max + ": " + sorted.toString();
     }
 }

--- a/src/main/java/com/example/survey/models/RangeQuestion.java
+++ b/src/main/java/com/example/survey/models/RangeQuestion.java
@@ -1,40 +1,23 @@
 package com.example.survey.models;
 
-import javax.persistence.ElementCollection;
 import javax.persistence.Entity;
-import javax.persistence.FetchType;
-import java.util.HashSet;
-import java.util.Set;
 
 @Entity
 public class RangeQuestion extends Question {
     private int min, max;
-    @ElementCollection(targetClass=Integer.class, fetch = FetchType.EAGER)
-    private Set<Answer> answers;
 
     public RangeQuestion() {
-        answers = new HashSet();
+        super();
     }
 
     public RangeQuestion(String question, int min, int max) {
-        this.question = question;
+        super(question);
         this.max = max;
         this.min = min;
-        answers = new HashSet();
     }
 
     @Override
     public String toString() {
         return question + " min " + min + " max " + max + ": " + answers.toString();
-    }
-
-    @Override
-    public Set<Answer> getAnswers() {
-        return answers;
-    }
-
-    @Override
-    public void addAnswer(Answer ans) {
-        answers.add(ans);
     }
 }

--- a/src/main/java/com/example/survey/models/RangeQuestion.java
+++ b/src/main/java/com/example/survey/models/RangeQuestion.java
@@ -4,31 +4,51 @@ import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import java.util.HashSet;
+import java.util.Set;
 
 @Entity
 public class RangeQuestion extends Question {
-    private int min, max, answer;
+    private int min, max;
+    private Set<Integer> answers;
 
     public RangeQuestion() {
+        answers = new HashSet();
     }
 
     public RangeQuestion(String question, int min, int max) {
         this.question = question;
         this.max = max;
         this.min = min;
+        answers = new HashSet();
     }
 
-    public void setAnswer(int answer) {
-        this.answer = answer;
+    public void addAnswer(int answer) {
+        answers.add(answer);
     }
 
     @Override
     public String toString() {
-        return question + " min " + min + " max " + max + ": " + answer;
+        return question + " min " + min + " max " + max + ": " + answers;
     }
 
     @Override
-    public String getAnswer() {
-        return "" + answer;
+    public Set<String> getAnswers() {
+        HashSet<String> toret = new HashSet();
+        for (int ans : answers) {
+            toret.add("" + ans);
+        }
+        return toret;
+    }
+
+    @Override
+    public void addAnswer(String ans) {
+        int response;
+        try {
+            response = Integer.parseInt(ans);
+        } catch (NumberFormatException e) {
+            response = 0;
+        }
+        addAnswer(response);
     }
 }

--- a/src/main/java/com/example/survey/models/TextQuestion.java
+++ b/src/main/java/com/example/survey/models/TextQuestion.java
@@ -1,35 +1,20 @@
 package com.example.survey.models;
 
 import javax.persistence.*;
-import java.util.HashSet;
-import java.util.Set;
 
 @Entity
 public class TextQuestion extends Question {
-    @ElementCollection(targetClass=String.class, fetch = FetchType.EAGER)
-    private Set<Answer> answers;
 
     public TextQuestion() {
-        answers = new HashSet();
+       super();
     }
 
     public TextQuestion(String question) {
-        this.question = question;
-        answers = new HashSet();
+        super(question);
     }
 
     @Override
     public String toString() {
         return question + ": " + answers.toString();
-    }
-
-    @Override
-    public Set<Answer> getAnswers() {
-        return answers;
-    }
-
-    @Override
-    public void addAnswer(Answer ans) {
-        answers.add(ans);
     }
 }

--- a/src/main/java/com/example/survey/models/TextQuestion.java
+++ b/src/main/java/com/example/survey/models/TextQuestion.java
@@ -1,29 +1,33 @@
 package com.example.survey.models;
 
 import javax.persistence.*;
+import java.util.HashSet;
+import java.util.Set;
 
 @Entity
 public class TextQuestion extends Question {
-    private String answer;
+    private Set<String> answers;
 
     public TextQuestion() {
+        answers = new HashSet();
     }
 
     public TextQuestion(String question) {
         this.question = question;
+        answers = new HashSet();
     }
 
-    @Override
-    public String getAnswer() {
-        return answer;
-    }
-
-    public void setAnswer(String answer) {
-        this.answer = answer;
+    public void addAnswer(String answer) {
+        answers.add(answer);
     }
 
     @Override
     public String toString() {
-        return question + ": " + answer;
+        return question + ": " + answers;
+    }
+
+    @Override
+    public Set<String> getAnswers() {
+        return answers;
     }
 }

--- a/src/main/java/com/example/survey/models/TextQuestion.java
+++ b/src/main/java/com/example/survey/models/TextQuestion.java
@@ -6,6 +6,7 @@ import java.util.Set;
 
 @Entity
 public class TextQuestion extends Question {
+    @ElementCollection(targetClass=String.class, fetch = FetchType.EAGER)
     private Set<String> answers;
 
     public TextQuestion() {
@@ -23,7 +24,7 @@ public class TextQuestion extends Question {
 
     @Override
     public String toString() {
-        return question + ": " + answers;
+        return question + ": " + answers.toString();
     }
 
     @Override

--- a/src/main/java/com/example/survey/models/TextQuestion.java
+++ b/src/main/java/com/example/survey/models/TextQuestion.java
@@ -7,7 +7,7 @@ import java.util.Set;
 @Entity
 public class TextQuestion extends Question {
     @ElementCollection(targetClass=String.class, fetch = FetchType.EAGER)
-    private Set<String> answers;
+    private Set<Answer> answers;
 
     public TextQuestion() {
         answers = new HashSet();
@@ -18,17 +18,18 @@ public class TextQuestion extends Question {
         answers = new HashSet();
     }
 
-    public void addAnswer(String answer) {
-        answers.add(answer);
-    }
-
     @Override
     public String toString() {
         return question + ": " + answers.toString();
     }
 
     @Override
-    public Set<String> getAnswers() {
+    public Set<Answer> getAnswers() {
         return answers;
+    }
+
+    @Override
+    public void addAnswer(Answer ans) {
+        answers.add(ans);
     }
 }

--- a/src/test/java/com/example/survey/models/AnswerTest.java
+++ b/src/test/java/com/example/survey/models/AnswerTest.java
@@ -1,0 +1,37 @@
+package com.example.survey.models;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class AnswerTest {
+
+    private Answer valAnswer, strAnswer;
+    @BeforeEach
+    public void setupTests() {
+        valAnswer = new Answer(1);
+        strAnswer = new Answer("UwU");
+    }
+
+    @Test
+    public void testSetGetVal() {
+        int expected = 2;
+        valAnswer.setVal(expected);
+        assertEquals(expected, valAnswer.getVal());
+    }
+
+    @Test
+    public void testSetGetResponse() {
+        String expected = "raccoon";
+        strAnswer.setResponse(expected);
+        assertEquals(expected, strAnswer.getResponse());
+    }
+
+    @Test
+    public void testToString() {
+        assertEquals("1", valAnswer.toString());
+        assertEquals("UwU", strAnswer.toString());
+    }
+
+}

--- a/src/test/java/com/example/survey/models/AnswerTest.java
+++ b/src/test/java/com/example/survey/models/AnswerTest.java
@@ -8,6 +8,7 @@ import static org.junit.jupiter.api.Assertions.*;
 class AnswerTest {
 
     private Answer valAnswer, strAnswer;
+
     @BeforeEach
     public void setupTests() {
         valAnswer = new Answer(1);
@@ -32,6 +33,13 @@ class AnswerTest {
     public void testToString() {
         assertEquals("1", valAnswer.toString());
         assertEquals("UwU", strAnswer.toString());
+    }
+
+    @Test
+    public void compareTo() {
+        valAnswer.setVal(1);
+        Answer valAnswer2 = new Answer(2);
+        assertEquals(-1, valAnswer.compareTo(valAnswer2));
     }
 
 }

--- a/src/test/java/com/example/survey/models/OptionQuestionTest.java
+++ b/src/test/java/com/example/survey/models/OptionQuestionTest.java
@@ -50,9 +50,9 @@ class OptionQuestionTest {
         oq.addOption("biden");
         oq.addOption("mama");
 
-        oq.setAnswer("mama");
+        oq.addAnswer("mama");
 
-        String expected = "who's joe? options (biden, mama): mama";
-        assertTrue(expected.equals(oq.toString()));
+        String expected = "who's joe? options (biden, mama): [mama]";
+        assertEquals(expected, oq.toString());
     }
 }

--- a/src/test/java/com/example/survey/models/OptionQuestionTest.java
+++ b/src/test/java/com/example/survey/models/OptionQuestionTest.java
@@ -50,7 +50,7 @@ class OptionQuestionTest {
         oq.addOption("biden");
         oq.addOption("mama");
 
-        oq.addAnswer("mama");
+        oq.addAnswer(new Answer("mama"));
 
         String expected = "who's joe? options (biden, mama): [mama]";
         assertEquals(expected, oq.toString());

--- a/src/test/java/com/example/survey/models/RangeQuestionTest.java
+++ b/src/test/java/com/example/survey/models/RangeQuestionTest.java
@@ -16,7 +16,7 @@ class RangeQuestionTest {
     @Test
     void testToString() {
         RangeQuestion rq = new RangeQuestion("how much does kirin bench (in lbs)?", 45, 205);
-        rq.addAnswer(45);
+        rq.addAnswer(new Answer(45));
         String expected = "how much does kirin bench (in lbs)? min 45 max 205: [45]";
         assertEquals(expected, rq.toString());
     }

--- a/src/test/java/com/example/survey/models/RangeQuestionTest.java
+++ b/src/test/java/com/example/survey/models/RangeQuestionTest.java
@@ -1,6 +1,7 @@
 package com.example.survey.models;
 
 import org.junit.jupiter.api.Test;
+import org.w3c.dom.ranges.Range;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -19,5 +20,26 @@ class RangeQuestionTest {
         rq.addAnswer(new Answer(45));
         String expected = "how much does kirin bench (in lbs)? min 45 max 205: [45]";
         assertEquals(expected, rq.toString());
+    }
+
+    @Test
+    void settersAndGetters() {
+        RangeQuestion rq = new RangeQuestion();
+        int minExpect = 1, maxExpect = 3;
+        rq.setMin(minExpect);
+        rq.setMax(maxExpect);
+        assertEquals(minExpect, rq.getMin());
+        assertEquals(maxExpect, rq.getMax());
+    }
+
+    @Test
+    void addAnswerOverride() {
+        RangeQuestion rq = new RangeQuestion("vals", 1, 3);
+        rq.addAnswer(new Answer(0));
+        rq.addAnswer(new Answer(1));
+        rq.addAnswer(new Answer(2));
+        rq.addAnswer(new Answer(3));
+        rq.addAnswer(new Answer(4));
+        assertEquals("vals min 1 max 3: [1, 2, 3]", rq.toString());
     }
 }

--- a/src/test/java/com/example/survey/models/RangeQuestionTest.java
+++ b/src/test/java/com/example/survey/models/RangeQuestionTest.java
@@ -8,16 +8,16 @@ class RangeQuestionTest {
 
     @Test
     void getQuestion() {
-        String expected =  "how much does kirin bench (in lsb)?";
-        RangeQuestion rq = new RangeQuestion(expected, 45, 240);
-        assertTrue(expected.equals(rq.getQuestion()));
+        String expected =  "how much does kirin bench (in lbs)?";
+        RangeQuestion rq = new RangeQuestion(expected, 45, 205);
+        assertEquals(expected, rq.getQuestion());
     }
 
     @Test
     void testToString() {
-        RangeQuestion rq = new RangeQuestion("how much does kirin bench (in lsb)?", 45, 240);
-        rq.setAnswer(45);
-        String expected = "how much does kirin bench (in lsb)? min 45 max 240: 45";
-        assertTrue(expected.equals(rq.toString()));
+        RangeQuestion rq = new RangeQuestion("how much does kirin bench (in lbs)?", 45, 205);
+        rq.addAnswer(45);
+        String expected = "how much does kirin bench (in lbs)? min 45 max 205: [45]";
+        assertEquals(expected, rq.toString());
     }
 }

--- a/src/test/java/com/example/survey/models/TextQuestionTest.java
+++ b/src/test/java/com/example/survey/models/TextQuestionTest.java
@@ -16,10 +16,11 @@ public class TextQuestionTest {
     }
 
     @Test
-    public void setAnswer() {
+    public void addAnswer() {
         String answer = "pepperoni";
-        question.setAnswer(answer);
+        String expected = q + ": " + "[" + answer + "]";
+        question.addAnswer(answer);
 
-        assertEquals(q + ": " + answer, question.toString());
+        assertEquals(expected, question.toString());
     }
 }

--- a/src/test/java/com/example/survey/models/TextQuestionTest.java
+++ b/src/test/java/com/example/survey/models/TextQuestionTest.java
@@ -17,7 +17,7 @@ public class TextQuestionTest {
 
     @Test
     public void addAnswer() {
-        String answer = "pepperoni";
+        Answer answer = new Answer("pepperoni");
         String expected = q + ": " + "[" + answer + "]";
         question.addAnswer(answer);
 


### PR DESCRIPTION
closes #36 

The readme specifies that questions can have multiple answers.

I chose to have the `Question` class specify the methods for adding an answer, and getting the set. It does not have the set of answers itself, as it is up to the Question subclasses to choose how to store those answers.
ex. RangeQuestion needs a `Set<Integer>`, but TextQuestion needs a `Set<String>`


the `@ElementCollection(targetClass=String.class, fetch = FetchType.EAGER)` are to prevent hibernate errors/warnings about not knowing types ahead of time.

After this, I want to work on #35 for the questions