### PR TITLE
Add react tests to CI

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -102,6 +102,16 @@
 										<arguments>install</arguments>
 								</configuration>
 						</execution>
+												
+						<execution>
+								<id>react-tests</id>
+								<goals>
+										<goal>yarn</goal>
+								</goals>
+								<configuration>
+										<arguments>test --watchAll=false</arguments>
+								</configuration>
+						</execution>
 
 						<execution>
 								<id>build-frontend</id>


### PR DESCRIPTION
Add react tests to our CI pipeline. 

Maven is garbage, it logs [jest](https://jestjs.io/) test runner logs as errors. 

<img width="424" alt="Screen Shot 2020-03-19 at 9 24 40 PM" src="https://user-images.githubusercontent.com/6130700/77128885-4067c500-6a28-11ea-98cc-7e8085475573.png">
